### PR TITLE
Update beagle-tester.c

### DIFF
--- a/beagle-tester.c
+++ b/beagle-tester.c
@@ -4461,7 +4461,7 @@ int test_techlab_cape(const char *scan_value, unsigned id)
 
 	/* Read accelerometer */
 	fd_accel = open("/dev/i2c-2", O_RDWR);
-	if (file < 0) {
+	if (fd_accel < 0) {
 		fail++;
 	}
 	beagle_notice("accel", fail ? "fail" : "pass");


### PR DESCRIPTION
This fixes the following error:
```
beagle-tester.c: In function ‘test_techlab_cape’:
beagle-tester.c:4464:6: error: ‘file’ undeclared (first use in this function); did you mean ‘fail’?
```